### PR TITLE
Switch over to official release-gem

### DIFF
--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -1,45 +1,28 @@
 name: Build and Release Gem
 on:
+  # This event will only trigger a workflow run if the workflow file is on the default branch.
+  # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_run
   workflow_run:
     workflows: ["Tests"]
     types:
       - completed
-  workflow_dispatch:
 
 jobs:
   release:
-    name: Release to GitHub Packages
+    name: Release to RubyGems.org
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/main' }}
     permissions:
       packages: write
       contents: write
 
     steps:
-    - uses: fac/ruby-gem-setup-credentials-action@v2
-      with:
-        user: ""
-        key: rubygems
-        token: ${{ secrets.FAC_RUBYGEMS_KEY }}
-
     # Build the gem package
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-    - run: bundle exec rake build
 
-    # Release production gem version from default branch
-    - name: Release
-      if:   github.ref == 'refs/heads/main'
-      uses: fac/ruby-gem-push-action@v2
-      with:
-        key: rubygems
-
-    # PR branch builds will release pre-release gems
-    - name: Pre-Release
-      if:   github.ref != 'refs/heads/main'
-      uses: fac/ruby-gem-push-action@v2
-      with:
-        key: rubygems
-        pre-release: true
+    # Release
+    - name: Release to RubyGems.org
+      uses: rubygems/release-gem@v1


### PR DESCRIPTION
# What
Switching over to use the official [release gem workflow](https://github.com/rubygems/release-gem).

Dunc and I have set up the gem as a [Trusted Publisher](https://guides.rubygems.org/trusted-publishing/adding-a-publisher/).

https://rubygems.org/gems/aws_local_config_parser/trusted_publishers
_Login creds available in LastPass_

Also:
- dropped `workflow_dispatch` support
- only try to release on merge to `main`