### PR TITLE
Bump `erb` to 6.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,14 +9,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
-    cgi (0.5.1)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
-    erb (4.0.4)
-      cgi (>= 0.3.3)
+    erb (6.0.4)
     ffi (1.17.2)
     ffi (1.17.2-arm64-darwin)
     inifile (3.0.0)
@@ -128,11 +126,10 @@ DEPENDENCIES
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   aws_local_config_parser (1.0.1)
-  cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
-  erb (4.0.4) sha256=de116e106205c46bc01918789b611aaad1328dcc6e9f12cf8cd2cc60ef619717
+  erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   ffi (1.17.2) sha256=297235842e5947cc3036ebe64077584bff583cd7a4e94e9a02fdec399ef46da6
   ffi (1.17.2-arm64-darwin) sha256=54dd9789be1d30157782b8de42d8f887a3c3c345293b57ffb6b45b4d1165f813
   inifile (3.0.0) sha256=b103eb3655ec93cc626cf2de00950e91f7e69b8398842968e17e1815cfacbfb0


### PR DESCRIPTION
We spotted this during Dependabots D&C, for some of our repos `erb` is lagging behind, but we have no explicit pinning.

Updating to the latest version to keep it aligned with our other repos.