### PR TITLE
Run Dependabot nightly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     cooldown:
       default-days: 7
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 20
     cooldown:
       default-days: 7


### PR DESCRIPTION
This will let all the Dependabot PRs be ready for Dev Platform's divide-and-conquer session on Mondays. Running every night, so priority changes will be ready to merge.

For fac/dev-platform#2571
